### PR TITLE
bump publish service 0.8.3..0.9.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     labels:
       - "logging=true"
   besluit-publicatie:
-    image: lblod/besluit-publicatie-publish-service:0.8.3
+    image: lblod/besluit-publicatie-publish-service:0.9.0
     links:
       - database:database
     restart: always


### PR DESCRIPTION
* bump base libraries (dd484d5)
* correctly preserve number of retries if operation stays pending (bb348b4)
* batch insert of extracted resources (9c21d22)
* print config on start (4199e00)
* also sort on publication date so earlier publications are published first (260f588)
* reschedule on failure (b3ac90a)
* catch errors in run queue (bb025bc)
* put resources that already failed before at the end of the queue (b6c7250)
* add .drone.yml file (2f75d93)
* include errorHandler (06a55fa)
* increase body parser limit to what delta notifier supports (4c81cb2)