### PR TITLE
bump resource to 1.21.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
     environment:
       RESCHEDULE_CRON_PATTERN: '15 7 * * *'
   resource:
-    image: semtech/mu-cl-resources:1.20.0
+    image: semtech/mu-cl-resources:1.21.0
     volumes:
       - ./config/resources:/config
     restart: always


### PR DESCRIPTION
this should solve our cache clearing issue when data is created by the besluit-publicatie service.