### PR TITLE
add a memory limit to the frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ x-logging: &default-logging
 services:
   publicatie:
     image: lblod/frontend-gelinkt-notuleren-publicatie:0.24.0
+    mem_limit: 2g    
     links:
       - identifier:backend
     restart: always


### PR DESCRIPTION
we have a memory leak in the frontend which causes fastboot to steal more and more memory over time. the quick fix is limiting the memory of the container which should cause a restart when it runs out. longer term we need to identify the memory leak and solve it.