### PR TITLE
bump publicatie publish service to 0.10.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     labels:
       - "logging=true"
   besluit-publicatie:
-    image: lblod/besluit-publicatie-publish-service:0.10.0
+    image: lblod/besluit-publicatie-publish-service:0.10.1
     links:
       - database:database
     restart: always


### PR DESCRIPTION
https://github.com/lblod/besluit-publicatie-publish-service/pull/8

filter out triples with whitespace object, causing queries to fail