### PR TITLE
GN-4299: addition of cached and raw sparql endpoints

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -2,11 +2,26 @@ defmodule Dispatcher do
   use Matcher
   define_accept_types [
     html: [ "text/html", "application/xhtml+html" ],
+    sparql: [ "application/sparql-results+json" ],
     any: [ "*/*" ]
   ]
 
   @html %{ accept: %{ html: true } }
   @any %{ accept: %{ any: true } }
+
+  ###############
+  # SPARQL
+  ###############
+
+  match "/sparql", %{ accept: %{ sparql: true } } do
+    Proxy.forward conn, [], "http://sparql-cache/sparql"
+  end
+
+  match "/raw-sparql", %{  accept: %{ sparql: true } } do
+    Proxy.forward conn, [], "http://database:8890/sparql"
+  end
+
+
 
   match "/published-resource-consumer/*path", @any do
     Proxy.forward conn, path, "http://published-resource-consumer/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,3 +129,8 @@ services:
     image: semtech/mu-file-service:3.1.0
     links:
       - database:database
+  sparql-cache:
+    image: redpencil/varnish-post:1.0.0
+    environment:
+      BACKEND_HOST: database
+    restart: always


### PR DESCRIPTION
### Overview
This PR adds the cached `/sparql` and raw `/raw-sparql` endpoints to the dispatcher. Using these endpoints, other applications can access publications using sparql.

Note this PR does not yet include a graphical user interface for the sparql endpoints.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-4299
Frontend PR contain yasgui page: https://github.com/lblod/frontend-gelinkt-notuleren-publicatie/pull/106
