### PR TITLE
GN-4435: Use `cool-uri` to create permalink for `zitting`

### DIFF
--- a/.changeset/fast-toys-rest.md
+++ b/.changeset/fast-toys-rest.md
@@ -1,0 +1,5 @@
+---
+"app-gn-publicatie": minor
+---
+
+GN-4435: Use `cool-uri` to create permalink for `zitting`

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -144,8 +144,8 @@ defmodule Dispatcher do
   # This will catch calls to pages {HOST}/Aalst/Gemeente/zitting/b2f47ed1-3534-11e9-a984-7db43f975d75
   # and redirect them to {HOST}/Aalst/Gemeente/zittingen/b2f47ed1-3534-11e9-a984-7db43f975d75
   # Note "zitting" vs "zittingen
-  match "/:bestuurseenheid_naam/:bestuurseenheid_classificatie_code_label/zitting/:id", @any do
-    conn = Plug.Conn.put_resp_header( conn, "location", "/" <> bestuurseenheid_naam <> "/" <> bestuurseenheid_classificatie_code_label <> "/zittingen/" <> id )
+  match "/:bestuurseenheid_naam/:bestuurseenheid_classificatie_code_label/zitting/*path", @any do
+    conn = Plug.Conn.put_resp_header( conn, "location", "/" <> bestuurseenheid_naam <> "/" <> bestuurseenheid_classificatie_code_label <> "/zittingen/" <> Enum.join( path, "/") )
     conn = send_resp( conn, 301, "" )
   end
 

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -137,6 +137,19 @@ defmodule Dispatcher do
     send_resp( conn, 404, "" )
   end
 
+  ###############
+  # PERMALINKS
+  ###############
+
+  # This will catch calls to links like {HOST}/Aalst/Gemeente/zitting/b2f47ed1-3534-11e9-a984-7db43f975d75
+  match "/:bestuurseenheid_naam/:bestuurseenheid_classificatie_code_label/zitting/:id", @any do
+    Proxy.forward conn, ["?uri=http://permalink", "zitting", id], "http://cooluri"
+  end
+
+  match "/permalink/*path", @any do
+    Proxy.forward conn, ["?uri=http://permalink"] ++ path, "http://cooluri"
+  end
+
   match "/*path", @html do
     # *_path allows a path to be supplied, but will not yield
     # an error that we don't use the path variable.

--- a/config/migrations/20231005111514-zitting-permalink.sparql
+++ b/config/migrations/20231005111514-zitting-permalink.sparql
@@ -1,0 +1,27 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        ?permalink foaf:page ?redirectUrl.
+    }
+}
+WHERE {
+    ?session rdf:type besluit:Zitting ;
+        mu:uuid ?zittingUuid ;
+        (besluit:isGehoudenDoor/mandaat:isTijdspecialisatieVan) ?administrativeUnit .
+    ?administrativeUnit besluit:bestuurt ?bestuurseenheid .
+    ?bestuurseenheid skos:prefLabel ?administrativeUnitName ;
+        (besluit:classificatie/skos:prefLabel) ?administrativeUnitTypeName .
+    BIND(URI(CONCAT("http://permalink/zitting/", ?zittingUuid)) AS ?permalink)
+    BIND(
+        CONCAT("/", ?administrativeUnitName, "/", ?administrativeUnitTypeName, "/zittingen/", ?zittingUuid)
+        AS ?redirectUrl
+    )
+}
+
+

--- a/config/migrations/20231005111514-zitting-permalink.sparql
+++ b/config/migrations/20231005111514-zitting-permalink.sparql
@@ -7,7 +7,7 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 
 INSERT {
     GRAPH <http://mu.semte.ch/graphs/public> {
-        ?permalink foaf:page ?redirectUrl.
+        ?session foaf:page ?redirectUrl.
     }
 }
 WHERE {
@@ -17,7 +17,6 @@ WHERE {
     ?administrativeUnit besluit:bestuurt ?bestuurseenheid .
     ?bestuurseenheid skos:prefLabel ?administrativeUnitName ;
         (besluit:classificatie/skos:prefLabel) ?administrativeUnitTypeName .
-    BIND(URI(CONCAT("http://permalink/zitting/", ?zittingUuid)) AS ?permalink)
     BIND(
         CONCAT("/", ?administrativeUnitName, "/", ?administrativeUnitTypeName, "/zittingen/", ?zittingUuid)
         AS ?redirectUrl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,3 +134,8 @@ services:
     environment:
       BACKEND_HOST: database
     restart: always
+  cooluri:
+    image: nvdk/cool-uris:1.0.0
+    environment:
+      SPARQL_ENDPOINT: "http://virtuoso:8890/sparql"
+      PORT: 80


### PR DESCRIPTION
### Overview

GN-4435: Use `cool-uri` to create permalink for `zitting`

Setup `cool-uri` service to provide permalinks for `zitting` (and other entities via `/permalink`)

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4435
https://github.com/lblod/besluit-publicatie-publish-service/pull/11

### Setup

1. Checkout
2. Checkout this PR https://github.com/lblod/besluit-publicatie-publish-service/pull/11 for `besluit-publicatie-publish-service`
3. Add following to `docker-compose.override.yml` 
   ```docker
    version: "3.4"
    services:
      besluit-publicatie:
        image: mu-javascript-template:latest
        environment:
          NODE_ENV: "development"
        volumes:
          - ./data/files/:/share/
          - /<LOCATION_OF_BESLUIT_SERVICE>/:/app/
   ```

Where `<LOCATION_OF_BESLUIT_SERVICE>` is folder where the `besluit-publicatie-publish-service` is checked out

4. `docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.override.yml up`

### How to test/reproduce

Confirm that migration was executed by running below query at http://localhost:8080/sparql

```sparql
PREFIX foaf: <http://xmlns.com/foaf/0.1/>
SELECT * WHERE {
  ?permalink foaf:page ?redirect .
} LIMIT 10
```

1. Try to access http://localhost:8080/Huldenberg/Gemeente/zitting/b2f47ed1-3534-11e9-a984-7db43f975d75, confirm you are redirected to http://localhost:8080/Huldenberg/Gemeente/zittingen/b2f47ed1-3534-11e9-a984-7db43f975d75 (note `zitting` vs `zittingen` in URL)
2. Try to access http://localhost:8080/permalink?uri=http://data.lblod.info/id/zittingen/8c93d2cc-f4ba-4444-b09e-b7495e336ff8, confirm you are redirected to http://localhost:8080/Huldenberg/Gemeente/zittingen/b2f47ed1-3534-11e9-a984-7db43f975d75
5. Call `curl -v http://localhost:8080/permalink?uri=http://data.lblod.info/id/zittingen/8c93d2cc-f4ba-4444-b09e-b7495e336ff8`, confirm you get `HTTP/1.1 303 See Other` and `location: /Huldenberg/Gemeente/zittingen/b2f47ed1-3534-11e9-a984-7db43f975d75` in the response headers

Confirm that besluit service is inserting permalink by either publishing something from GN, if you have it setup, or going to http://localhost:8080/sparql and executing following query

```sparql
PREFIX sign: <http://mu.semte.ch/vocabularies/ext/signing/>

INSERT DATA {
GRAPH <http://mu.semte.ch/graphs/public> {
    <http://data.lblod.info/published-resources/0cf4b620-45f9-11ec-99f4-b935d359b4a5> a sign:PublishedResource ;
        <http://purl.org/dc/terms/created> "2023-10-04T09:47:30.818Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        sign:text """<div class="au-c-template au-c-template--treatment behandeling"
     prefix="eli: http://data.europa.eu/eli/ontology# prov: http://www.w3.org/ns/prov# mandaat: http://data.vlaanderen.be/ns/mandaat# besluit: http://data.vlaanderen.be/ns/besluit# ext: http://mu.semte.ch/vocabularies/ext/ person: http://www.w3.org/ns/person# persoon: http://data.vlaanderen.be/ns/persoon# dateplugin: http://say.data.gift/manipulators/insertion/ besluittype: https://data.vlaanderen.be/id/concept/BesluitType/ dct: http://purl.org/dc/terms/ mobiliteit: https://data.vlaanderen.be/ns/mobiliteit# lblodmow: http://data.lblod.info/vocabularies/mobiliteit/">
    <div about="http://data.lblod.info/id/zittingen/6515CDF42C0D037764237179" typeof="besluit:Zitting"><span
            property="http://data.vlaanderen.be/ns/besluit#isGehoudenDoor"
            resource="http://data.lblod.info/id/bestuursorganen/28dca2b0f60eb33cdb72e8398fa63e19352f8fa67dfaa3a7784d83498d521bcf"></span>
        <span property="http://data.vlaanderen.be/ns/besluit#geplandeStart" content="2023-09-28T17:00:51.870Z"
              datatype="http://www.w3.org/2001/XMLSchema#dateTime"></span> <span
                property="http://www.w3.org/ns/prov#startedAtTime" content="2023-09-28T17:00:51.870Z"
                datatype="http://www.w3.org/2001/XMLSchema#dateTime" class="is-required"></span> <span
                property="http://www.w3.org/ns/prov#endedAtTime" content="2023-09-28T19:05:26.580Z"
                datatype="http://www.w3.org/2001/XMLSchema#dateTime"></span>
        <div class="au-c-template au-c-template--treatment" typeof="besluit:BehandelingVanAgendapunt"
             resource="http://data.lblod.info/id/behandelingen-van-agendapunten/6515CE5F2C0D03776423717A"><p
                content="true" datatype="xsd:boolean" property="besluit:openbaar"><span class="au-c-template-public">Openbare behandeling van agendapunt</span>
        </p>
            <h3 resource="http://data.lblod.info/id/agendapunten/6515CE602C0D03776423717B" property="dc:subject"><span
                    property="dc:title">besluit mbt vastgoedinformatieplatform</span> (<span
                    property="besluit:Agendapunt.type"
                    resource="http://lblod.data.gift/concepts/bdf68a65-ce15-42c8-ae1b-19eeb39e20d0"
                    typeof="skos:Concept">gepland</span>) </h3> <h4>Aanwezigen bij agendapunt</h4>

            <h4>Stemmingen bij agendapunt</h4>
            <div class="c-template-content c-template-content--treatment"></div>
        </div>
    </div>
</div>
""" .
}
}
```

Then after running 

```sparql
PREFIX foaf: <http://xmlns.com/foaf/0.1/>
SELECT * WHERE {
  <http://data.lblod.info/id/zittingen/6515CDF42C0D037764237179> foaf:page ?redirect .
} LIMIT 10
```

You should be able to observe something like this, note that the ID part of the URL will be different

<img width="560" alt="CleanShot 2023-10-09 at 11 14 09@2x" src="https://github.com/lblod/app-gn-publicatie/assets/769698/c06a3402-8000-4a48-97f2-4afe7cad162c">



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
