### PR TITLE
Support the publication of large meeting notulen

### DIFF
--- a/.changeset/little-tools-rhyme.md
+++ b/.changeset/little-tools-rhyme.md
@@ -1,0 +1,5 @@
+---
+"app-gn-publicatie": minor
+---
+
+Support publication of large meetings

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -13,6 +13,21 @@
 ;; COMMON MODELS ;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define-resource file ()
+  :class (s-prefix "nfo:FileDataObject")
+  :properties `((:name :string ,(s-prefix "nfo:fileName"))
+                (:format :string ,(s-prefix "dct:format"))
+                (:size :number ,(s-prefix "nfo:fileSize"))
+                (:extension :string ,(s-prefix "dbpedia:fileExtension"))
+                (:created :datetime ,(s-prefix "nfo:fileCreated")))
+  :has-one `((file :via ,(s-prefix "nie:dataSource")
+                   :inverse t
+                   :as "download"))
+  :resource-base (s-url "http://data.example.com/files/")
+  :features `(include-uri)
+  :on-path "files"
+)
+
 (define-resource concept ()
   :class (s-prefix "skos:Concept")
   :properties `((:label :string ,(s-prefix "skos:prefLabel"))
@@ -174,7 +189,9 @@
                       :inverse t
                       :as "zitting")
              (published-resource :via ,(s-prefix "prov:wasDerivedFrom")
-                                  :as "publication"))
+                                  :as "publication")
+             (file :via ,(s-prefix "prov:generated")
+                   :as "file"))
   :resource-base (s-url "http://data.lblod.info/id/notulen/")
   :features '(include-uri)
   :on-path "notulen"

--- a/config/resources/repository.lisp
+++ b/config/resources/repository.lisp
@@ -26,6 +26,10 @@
 (add-prefix "schema" "http://schema.org/")
 (add-prefix "rdfs" "http://www.w3.org/2000/01/rdf-schema#")
 
+(add-prefix "nfo" "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#")
+(add-prefix "nie" "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#")
+(add-prefix "dbpedia" "http://dbpedia.org/ontology/")
+
 (add-prefix "sign" "http://mu.semte.ch/vocabularies/ext/signing/")
 (add-prefix "lblodlg" "http://data.lblod.info/vocabularies/leidinggevenden/")
 (add-prefix "lblodmow" "http://data.lblod.info/vocabularies/mobiliteit/")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ x-logging: &default-logging
     max-file: "3"
 services:
   publicatie:
-    image: lblod/frontend-gelinkt-notuleren-publicatie:1.4.0
+    image: lblod/frontend-gelinkt-notuleren-publicatie:1.5.0
     mem_limit: 4g
     links:
       - identifier:backend
@@ -75,7 +75,7 @@ services:
     labels:
       - "logging=true"
   besluit-publicatie:
-    image: lblod/besluit-publicatie-publish-service:0.12.2
+    image: lblod/besluit-publicatie-publish-service:0.13.0
     links:
       - database:database
     restart: always


### PR DESCRIPTION
-------

### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

While we already have publications coming in as files from GN, the publish service was still 
enhancing the html and storing that as a db string, generating the same problems as before.
Additionally, that service was very very inefficient, and crashing seemingly at random for 
large publications. I suspect it was simply hitting some kind of resource limits, but I can't 
be sure.

In any case, the publish service has been greatly optimized in the linked PR and the frontend
has been updated to accommodate the file storage. 

On the app config itself, I added the file config to the resources config to support the changes in the frontend.


##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->
JIRA: https://binnenland.atlassian.net/browse/GN-4775

service: https://github.com/lblod/besluit-publicatie-publish-service/pull/13
frontend: https://github.com/lblod/frontend-gelinkt-notuleren-publicatie/pull/123

### Setup
<!-- PR dependencies -->
<!-- override snippets -->
This app has always assumed it runs on the same machine as Gelinkt Notuleren and required 
a volume mount for the GN files (this was initially done for attachments, but is now also used 
for the publications).

This kind of setup is also used in production.

(for both of the below configs: merge with what you already have, dont completely overwrite your override file)

app-gelinkt-notuleren-publicatie: docker-compose.override

``` yaml
services:
  publicatie:
    image: !reset null
    build: https://github.com/lblod/frontend-gelinkt-notuleren-publicatie.git#feat/publication-as-files

  besluit-publicatie:
    image: !reset null
    build: https://github.com/lblod/besluit-publicatie-publish-service.git#fix/publication-as-files
    volumes:
      - <location of your app-gelinkt-notuleren folder>/data/files/:/share/
  file:
    volumes:
      - <location of your app-gelinkt-notuleren folder>/data/files/:/share/
      
  # enable the following for linking the consumer to a local stack
  # assumes the app-gn stack is running locally on your host
  # and you've renamed the GN identifier to identifier-gelinkt-notuleren
  published-resource-consumer:

    environment:
      NODE_ENV: development
      SERVICE_NAME: 'published-resource-consumer'

      SYNC_BASE_URL: 'http://identifier-gelinkt-notuleren'
      # for faster ingesting, poll every 5 seconds instead of every minute
      INGEST_INTERVAL: 5000
    networks:
      - default
      - shared-gn-pub

networks:
  shared-gn-pub:
    name: shared-gn-pub
    external: true
```

app-gelinkt-notulereln: docker-compose.override

``` yaml
services:
  identifier:
    networks:
      default:
      shared-gn-pub:
        aliases:
          - "identifier-gelinkt-notuleren"

networks:
  shared-gn-pub:
    name: shared-gn-pub
```



### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

- Start up the GN stack first, as it will create the shared network
- with the above config, anything you publish on the GN stack should show up on the publication stack within 5-10 seconds
- try to publish a bunch of things and check if it all works, especially larger meetings with a lot of html content in the notulen (tip: votings and participants on agenda items add a lot of html)


### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations