### PR TITLE
Fix restart configuration for services

### DIFF
--- a/.changeset/quiet-badgers-wash.md
+++ b/.changeset/quiet-badgers-wash.md
@@ -1,0 +1,5 @@
+---
+"app-gn-publicatie": patch
+---
+
+Always restart services in production, never in development

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,10 +8,16 @@ x-logging: &default-logging
 services:
   publicatie:
     restart: "no"
+  dispatcher:
+    restart: "no"
   identifier:
     ports:
       - "8080:80"
     restart: "no"
+    environment:
+      SESSION_COOKIE_SECURE: "false"
+      # SAME_SITE: "None" doesn't work with insecure cookies
+      SESSION_COOKIE_SAME_SITE: "Lax"
   database:
     restart: "no"
   virtuoso:
@@ -31,12 +37,22 @@ services:
   publicatie-melding:
     restart: "no"
     command: "/bin/false" # overwrite when testing
+  resource:
+    restart: "no"
+  deltanotifier:
+    restart: "no"
+  published-resource-consumer:
+    restart: "no"
   taskmetrics:
     restart: "no"
   file:
     restart: "no"
     volumes:
         - ../app-gelinkt-notuleren/data/files/:/share/
+  sparql-cache:
+    restart: "no"
+  cooluri:
+    restart: "no"
   # # enable the following for linking the consumer to a local stack
   # # assumes the app-gn stack is running locally on your host
   # # and you've renamed the identifier to identifier-gelinkt-notuleren

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,10 +123,12 @@ services:
       - ./config/consumer/:/config/
   taskmetrics:
     image: lblod/task-metrics-service:1.0.0
+    restart: always
     links:
       - database:database
   file:
     image: semtech/mu-file-service:3.1.0
+    restart: always
     links:
       - database:database
   sparql-cache:
@@ -136,6 +138,7 @@ services:
     restart: always
   cooluri:
     image: nvdk/cool-uris:1.0.0
+    restart: always
     environment:
       SPARQL_ENDPOINT: "http://virtuoso:8890/sparql"
       PORT: 80


### PR DESCRIPTION
### Overview
I noticed these were wrong when testing a PR.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Start the stack (prod config), restart the docker daemon (or your machine), see that the services start.
Then do the same with the dev config and see that they do not.

### Challenges/uncertainties
I added the secure cookies config a while ago. I can't remember what problem it was to solve, but since it's on the dev config and it's on GN, I figured I might as well add it...

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [ ] no new deprecations
