### PR TITLE
Add example overrides to show how to do some common configuration

### DIFF
--- a/.changeset/ninety-goats-arrive.md
+++ b/.changeset/ninety-goats-arrive.md
@@ -1,0 +1,5 @@
+---
+"app-gn-publicatie": patch
+---
+
+Add example docker overrides to aid local development

--- a/.woodpecker/validate-resource-models.yml
+++ b/.woodpecker/validate-resource-models.yml
@@ -3,6 +3,7 @@ clone:
     image: woodpeckerci/plugin-git
     settings:
       lfs: false
+      remote: ${CI_REPO_CLONE_URL}
 
 steps:
   validate-resource-models:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,25 +53,3 @@ services:
     restart: "no"
   cooluri:
     restart: "no"
-  # # enable the following for linking the consumer to a local stack
-  # # assumes the app-gn stack is running locally on your host
-  # # and you've renamed the identifier to identifier-gelinkt-notuleren
-  # published-resource-consumer:
-  #   image: lblod/gelinkt-notuleren-consumer
-  #   restart: "no"
-  #   environment:
-  #     NODE_ENV: development
-  #     SERVICE_NAME: 'published-resource-consumer'
-
-  #     SYNC_BASE_URL: 'http://identifier-gelinkt-notuleren'
-  #     INGEST_INTERVAL: 60000
-  #   volumes:
-  #     - ./config/consumer/:/config/
-  #   networks:
-  #     - default
-  #     - gelinkt-notuleren
-
-  # networks:
-  #   gelinkt-notuleren:
-  #     external:
-  #       name: app-gelinkt-notuleren_default

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,53 @@
+services:
+  # # Add identifier to shared network that allows another service, e.g. a harvester, to make
+  # # requests to the publisher
+  # # Tell publicatie that it should allow fastboot for the requests coming from the harvester
+  # identifier:
+  #   networks:
+  #     default:
+  #     shared-gn-harvest:
+  #       aliases:
+  #         - "identifier-gn-publicatie"
+  # publicatie:
+  #   environment:
+  #     EMBER_ADDITIONAL_FASTBOOT_HOST: "identifier-gn-publicatie"
+  #   links:
+  #     - identifier:backend
+
+  # # enable the following for linking the consumer to a local stack
+  # # assumes the app-gn stack is running locally on your host
+  # # and you've renamed the identifier to identifier-gelinkt-notuleren
+  # # Requires network config here and in the GN app
+  # published-resource-consumer:
+  #   environment:
+  #     SERVICE_NAME: 'published-resource-consumer'
+  #     SYNC_BASE_URL: 'http://identifier-gelinkt-notuleren'
+  #     INGEST_INTERVAL: 5000
+  #   networks:
+  #     - default
+  #     - shared-gn-pub
+  #   volumes:
+  #     - ./config/consumer/:/config/
+
+  # Connect app-gn's files as a volume so they're accessible
+  besluit-publicatie:
+    volumes:
+      - ../app-gelinkt-notuleren/data/files/:/share/
+  file:
+    volumes:
+      - ../app-gelinkt-notuleren/data/files/:/share/
+
+  # Allow access to sparql for web UIs such as yasgui
+  virtuoso:
+    environment:
+      ENABLE_CORS: true
+
+# networks:
+#   # Connect to a network shared by local GN so that we can consume from it
+#   shared-gn-pub:
+#     name: shared-gn-pub
+#     external: true
+
+#   # Create a shared network that a harvester can connect to, to scrape published documents
+#   shared-gn-harvest:
+#     name: shared-gn-harvest


### PR DESCRIPTION
### Overview
Add an example overrides file with ready-made overrides for things such as connecting to different locally running stacks.

##### connected issues and PRs:
Includes config only useful with https://github.com/lblod/frontend-gelinkt-notuleren-publicatie/pull/130

### Setup
To test use with a local harvester, it's necessary to run with the version from the frontend PR. Some config might need tweaking for your local set-up.

### How to test/reproduce
Test that you can consume from a local GN and be harvested by a local harvester. See https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/579 for instructions.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
